### PR TITLE
Docs: Add external link validation with lychee

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ scale by manipulating declarative Configuration as Data.
 
 See [the FAQ](https://kpt.dev/faq/) for more details about how kpt is different from alternatives.
 
-Use our [public Dosu space](https://github.dosu.com/kptdev/kpt) to ask anything about kpt.
+Use our [public Dosu space](https://app.dosu.dev/b19fb34f-d249-48ae-a3b1-2bd8ec156e41/ask) to ask anything about kpt.
 
 ## Why kpt?
 

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -16,6 +16,11 @@ serve:
 verify:
 	go run github.com/golangci/misspell/cmd/misspell@v0.8.0 -error content/
 
+.PHONY: check-links-external
+check-links-external: production-build
+	@command -v lychee >/dev/null 2>&1 || { echo "Error: lychee not found. Install it from https://github.com/lycheeverse/lychee#installation"; exit 1; }
+	lychee 'public/**/*.html'
+
 production-build:
 	git submodule update --init --recursive
 	git fetch --tags

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -33,6 +33,34 @@ The site pulls some dependencies via Git submodules. If `npm install` succeeds b
 git submodule update --init --recursive
 ```
 
+## Checking external links
+
+To validate external links in the documentation, use:
+
+```sh
+make check-links-external
+```
+
+This builds the site with Hugo and runs [lychee](https://github.com/lycheeverse/lychee) against the rendered HTML.
+
+### Prerequisites
+
+- **Hugo** — installed via `npm install` (from `devDependencies`) or [standalone](https://gohugo.io/installation/)
+- **lychee** — install via one of:
+  - macOS: `brew install lychee`
+  - Linux/macOS (Cargo): `cargo install lychee`
+  - Binary download: see [lychee releases](https://github.com/lycheeverse/lychee/releases)
+
+### Using a GitHub token
+
+To avoid GitHub rate limiting, pass a token:
+
+```sh
+GITHUB_TOKEN=$(gh auth token) make check-links-external
+```
+
+The token is only sent to github.com domains.
+
 ## Style guide for documentation
 
 1. Use US English in the documentation

--- a/documentation/content/en/_index.md
+++ b/documentation/content/en/_index.md
@@ -47,7 +47,7 @@ kpt is an open source project and anyone can [contribute](https://github.com/kpt
 To get familiar with kpt, the best way to start is with the first 4 chapters of the kpt [Book]({{% relref "book" %}}).
 Furthermore it is useful to check the [references]({{% relref "reference" %}}) and the catalog of [selected krm functions](https://catalog.kpt.dev).
 
-Use our [public Dosu space](https://github.dosu.com/kptdev/kpt) to ask anything about kpt.
+Use our [public Dosu space](https://app.dosu.dev/b19fb34f-d249-48ae-a3b1-2bd8ec156e41/ask) to ask anything about kpt.
 
 # For admins
 

--- a/documentation/content/en/book/01-getting-started/_index.md
+++ b/documentation/content/en/book/01-getting-started/_index.md
@@ -30,7 +30,7 @@ configured.
 
 #### Docker
 
-Follow the [instructions](https://docs.docker.com/get-docker) to install and configure Docker.
+Follow the [instructions](https://docs.docker.com/get-started/get-docker/) to install and configure Docker.
 
 #### Podman
 

--- a/documentation/content/en/book/04-using-functions/_index.md
+++ b/documentation/content/en/book/04-using-functions/_index.md
@@ -739,7 +739,7 @@ kpt fn eval wordpress -i kubeconform:latest --network -- schema_location="https:
 
 #### Mounting directories
 
-By default, the functions cannot access the host file system. You can use the `--mount` flag to mount the host volumes. kpt accepts the same options to `--mount`, as specified on the [Docker Volumes](https://docs.docker.com/storage/volumes/) page.
+By default, the functions cannot access the host file system. You can use the `--mount` flag to mount the host volumes. kpt accepts the same options to `--mount`, as specified on the [Docker Volumes](https://docs.docker.com/engine/storage/volumes/) page.
 
 The `kubeconform` function can, for example, consume a JSON schema file, as follows:
 

--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -127,7 +127,7 @@ for writing functions that manipulate KRM. Go provides:
 
 - [Install kpt]({{% relref "/installation/kpt-cli" %}})
 
-- [Install Docker](https://docs.docker.com/get-docker/)
+- [Install Docker](https://docs.docker.com/get-started/get-docker/)
 
 - [Golang](https://go.dev/dl/) (at least version 1.24)
 

--- a/documentation/content/en/book/07-effective-customizations/_index.md
+++ b/documentation/content/en/book/07-effective-customizations/_index.md
@@ -326,7 +326,7 @@ The mutation pipeline fails because the Rego policy has been violated.
 When using template languages I am able to provide conditional statements based 
 on parameter values.  This allows me to ask the user for a little bit of 
 information and generate a lot of boilerplate configuration.  Some template 
-languages like [Jinja](https://palletsprojects.com/p/jinja/) are very robust and feature rich.
+languages like [Jinja](https://palletsprojects.com/projects/jinja/) are very robust and feature rich.
 
 ### Problems:
 

--- a/documentation/content/en/installation/migration.md
+++ b/documentation/content/en/installation/migration.md
@@ -355,7 +355,7 @@ kpt `v0.39`) to `v1` version(compatible with kpt `v1.0`).
 
 [v0.39 commands]: https://kptdev.github.io/kpt/reference/
 [v1.0 commands]: /reference/cli/
-[v1 kptfile]: https://github.com/kptdev/kpt/blob/main/pkg/api/kptfile/v1/types.go
+[v1 kptfile]: https://github.com/kptdev/kpt/blob/main/api/kptfile/v1/types.go
 [starlark function]: https://catalog.kpt.dev/starlark/v0.2/
 [apply-setters]: https://catalog.kpt.dev/apply-setters/v0.1/
 [setter inheritance]: https://kptdev.github.io/kpt/concepts/setters/#inherit-setter-values-from-parent-package
@@ -363,10 +363,10 @@ kpt `v0.39`) to `v1` version(compatible with kpt `v1.0`).
 [required setters]: https://kptdev.github.io/kpt/guides/producer/setters/#required-setters
 [auto-setters]: https://kptdev.github.io/kpt/concepts/setters/#auto-setters
 [migrating inventory objects]: https://kptdev.github.io/kpt/reference/live/alpha/
-[live migration]: https://kptdev.github.io/kpt/reference/cli/live/alpha/
+[live migration]: https://kptdev.github.io/kpt/reference/live/alpha/
 [configpath]: /book/04-using-functions/01-declarative-function-execution?id=configpath
-[example kpt package]: https://github.com/kptdev/krm-functions-catalog/tree/master/testdata/fix
-[simple example]: https://github.com/kptdev/krm-functions-catalog/tree/master/functions/go/fix#examples
+[example kpt package]: https://github.com/kptdev/krm-functions-catalog/tree/main/archived/functions/go/fix/testdata/fix
+[simple example]: https://github.com/kptdev/krm-functions-catalog/tree/main/archived/functions/go/fix#examples
 [function config]: /book/04-using-functions/01-declarative-function-execution?id=configpath
 [starlark runtime]: https://kptdev.github.io/kpt/guides/producer/functions/starlark/
 [update guide]: /book/03-packages/05-updating-a-package
@@ -377,6 +377,6 @@ kpt `v0.39`) to `v1` version(compatible with kpt `v1.0`).
 [installation instructions]: /installation/
 [install]: /installation/
 [kpt-functions-catalog]: https://catalog.kpt.dev/
-[v1alpha1 kptfile]: https://github.com/kptdev/kpt/blob/master/pkg/kptfile/pkgfile.go#L39
+[v1alpha1 kptfile]: https://github.com/kptdev/kpt/blob/v0/pkg/kptfile/pkgfile.go#L39
 [git clone]: https://git-scm.com/docs/git-clone
 [publish your package]: /book/03-packages/08-publishing-a-package

--- a/documentation/content/en/reference/cli/fn/eval/_index.md
+++ b/documentation/content/en/reference/cli/fn/eval/_index.md
@@ -322,5 +322,5 @@ $ KRM_FN_RUNTIME=podman kpt fn eval DIR -i ghcr.io/example.com/my-fn
 
 <!--mdtogo-->
 
-[docker volumes]: https://docs.docker.com/storage/volumes/
+[docker volumes]: https://docs.docker.com/engine/storage/volumes/
 [imperative function execution]: /book/04-using-functions/#imperative-function-execution

--- a/documentation/content/en/reference/schema/config-connector-status-convention/_index.md
+++ b/documentation/content/en/reference/schema/config-connector-status-convention/_index.md
@@ -8,11 +8,11 @@ menu:
     parent: "Schema Reference"
 ---
 
-`kpt` includes custom rules for [Config Connector](https://cloud.google.com/config-connector/docs/overview) resources to
+`kpt` includes custom rules for [Config Connector](https://docs.cloud.google.com/config-connector/docs/overview) resources to
 make them easier to work with. This document describes how kpt uses fields and conditions on Config Connector
 resources to compute [reconcile status]({{% relref "/book/06-deploying-packages#reconcile-status" %}}).
 
-[Config Connector](https://cloud.google.com/config-connector/docs/how-to/monitoring-your-resources) resources expose the
+[Config Connector](https://docs.cloud.google.com/config-connector/docs/how-to/monitoring-your-resources) resources expose the
 `observedGeneration` field in the status object, and `kpt` will always report a resource as being `InProgress` if the
 `observedGeneration` doesn't match the value of `metadata.generation`.
 
@@ -22,7 +22,7 @@ as `Current`, i.e it has been successfully reconciled.
 If the `Ready` condition is `False`, `kpt` will look at the `Reason` field on the
 condition object to determine whether the resource is making progress towards
 reconciliation. The possible values mirrors those used by
-[Config Connector events](https://cloud.google.com/config-connector/docs/how-to/monitoring-your-resources#viewing_events).
+[Config Connector events](https://docs.cloud.google.com/config-connector/docs/how-to/monitoring-your-resources#viewing_events).
 If the value is one of the following, the resource is considered to have failed
 reconciliation:
 - `ManagementConflict`

--- a/documentation/content/en/reference/schema/crd-status-convention/_index.md
+++ b/documentation/content/en/reference/schema/crd-status-convention/_index.md
@@ -10,7 +10,7 @@ menu:
 
 To enable kpt to calculate the [reconcile status]({{% relref "/book/06-deploying-packages#reconcile-status" %}}) for CRDs, this
 document provides additional conventions for status conditions following the
-[Kubernetes API Guideline](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+[Kubernetes API Guideline](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md).
 Custom controllers should use the following conditions types to signal whether a resource has been fully reconciled, and
 whether it has encountered any problems:
 

--- a/documentation/layouts/partials/footer.html
+++ b/documentation/layouts/partials/footer.html
@@ -93,7 +93,7 @@
 				kpt follows <a href="{{ .Site.Params.code_of_conduct }}" target="_blank" rel="noopener">The CNCF Code of Conduct</a> | 
 				This site was built with the <a href="https://www.docsy.dev/">Docsy</a> <a href="https://gohugo.io/">Hugo</a> 
 				theme and deployed to Netlify.</small>
-				<a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-color-bg.svg" alt="Deploys by Netlify" height="25"/> </a> </br>
+				<a href="https://www.netlify.com"> <img src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg" alt="Deploys by Netlify" height="25"/> </a> </br>
 				For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies</a>. </br>
 				The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, 
          please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark Usage page</a>.


### PR DESCRIPTION
## Description
  - What changed: Added external link validation using `lychee` for the kpt documentation site, with a weekly CI workflow and a local `make` target.
  - Why it's needed: External links break over time as upstream projects move, rename, or archive content. Automated weekly checking catches dead links before users encounter them.
  - How it works: Hugo builds the site, then `lychee` checks all external (http/https) links in the rendered HTML. A `lychee.toml` config handles exclusions and rate limiting.

  ## Related Issue(s)
  - None

  ## Type of Change
  - [x] Documentation
  - [x] New feature

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## Testing Instructions (Optional)
  1. `cd documentation`
  2. Install lychee: https://github.com/lycheeverse/lychee#installation
  3. `GITHUB_TOKEN=$(gh auth token) make check-links-external`
  4. Verify 0 errors reported

  ## Additional Notes (Optional)
  - Known issues: GitHub org project boards (`/orgs/*/projects/`) return 404 to bots even when publicly visible in a browser session. These are excluded.
  - Further improvements: Re-evaluate GitHub `edit`/`issues/new` exclusions if lychee adds per-domain auth header support. Consider adding the link check to PR workflows once lychee is
  available in CI runners by default.

  ## AI Disclosure
  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to implement the lychee configuration, Makefile target, CI workflow, and README documentation.